### PR TITLE
[ROR] Use the custom Java environment

### DIFF
--- a/report.tex
+++ b/report.tex
@@ -17,30 +17,40 @@
 % Source code
 \usepackage{listingsutf8}
 %% Java
-\lstnewenvironment{Java}{%
+%%% block
+\lstnewenvironment{Java}[1][]{%
   \lstset{%
     columns=fixed,%
     language=java,%
-  }
+    frame=tb,%
+    captionpos=b,%
+    #1%
+  }%
 }{}
+%%% inline
 \newcommand{\java}[1]{%
   \lstinline[%
     columns=fixed,%
     language=java
-  ]{#1}
+  ]{#1}%
 }
 %% JVM
-\lstnewenvironment{JVM}{%
+%%% block
+\lstnewenvironment{JVM}[1][]{%
   \lstset{%
     columns=fixed,%
     language={},%
-  }
+    frame=tb,%
+    captionpos=b,%
+    #1%
+  }%
 }{}
+%%% inline
 \newcommand{\jvm}[1]{%
   \lstinline[
     columns=fixed,%
     language={},%
-  ]{#1}
+  ]{#1}%
 }
 
 % Macros

--- a/section/first_phase/ror.tex
+++ b/section/first_phase/ror.tex
@@ -50,13 +50,8 @@ However, we were able to reduce the number of changes required between each impl
 Listing~\ref{lst:ror:enum} shows an excerpt of the enumeration of the zero-comparing opcodes.
 Listing~\ref{lst:ror:MethodVisitor} shows one of the enum iterations from the ROR mutator's \java{MethodVisitor}.
 
-\begin{lstlisting}[%
-  language=Java,
-  frame=tb,
-  caption={%
-    Excerpt of \java{enum} Declaration for ROR
-  },
-  captionpos=b,
+\begin{Java}[%
+  caption={Excerpt of \java{enum} Declaration for ROR},
   label={lst:ror:enum}]
 enum OpcodeCompareToZero {
   IFEQ(Opcodes.IFEQ) {
@@ -81,15 +76,10 @@ enum OpcodeCompareToZero {
     return this.opcode;
   }
 }
-\end{lstlisting}
+\end{Java}
 
-\begin{lstlisting}[%
-  language=Java,
-  frame=tb,
-  caption={%
-    Excerpt of ROR's \java{MethodVisitor}
-  },
-  captionpos=b,
+\begin{Java}[%
+  caption={Excerpt of ROR's \java{MethodVisitor}},
   label={lst:ror:MethodVisitor}]
 // The operands will seem to be in the wrong
 // order when used in else conditions.
@@ -107,4 +97,4 @@ for (OpcodeCompareToZero original
         + " to " + REPLACEMENT_OP));
   }
 }
-\end{lstlisting}
+\end{Java}


### PR DESCRIPTION
Using a custom listings environment allows many optional arguments to
be standardized as part of the environment itself.